### PR TITLE
41 gitea from GitHub

### DIFF
--- a/app/services/custom_error.ts
+++ b/app/services/custom_error.ts
@@ -59,6 +59,17 @@ export class GitRepositoryNotATemplate extends GitRepositoryError {
   }
 }
 
+export class GitContentFileNotFound implements IsPrintableErrorMessage {
+  constructor(
+    private repo: string,
+    private file: string
+  ) {}
+
+  getPrintableErrorMessage(i18n: I18n): string {
+    return i18n.t('file_not_found', { file: this.file, repo: this.repo })
+  }
+}
+
 export class UserNotFound implements IsPrintableErrorMessage {
   constructor(private username: string) {}
 

--- a/app/services/gitea_api_service.ts
+++ b/app/services/gitea_api_service.ts
@@ -71,6 +71,27 @@ export default class GiteaApiService {
     }
   }
 
+  async convertToTemplate(repo_name: string) {
+    await this.getOwner()
+    const url: string = `/repos/${this.owner_name}/${repo_name}`
+    const body = { template: true }
+    try {
+      return await this.http_service.patch(url, body)
+    } catch (error) {
+      let externalError: ExternalAPIError = new ExternalAPIError(
+        error.response.status,
+        error.response.data,
+        error,
+        error.response.data.message
+      )
+      if (error.response.status === 404) {
+        externalError.addErrorDetails(new GitRepositoryNotFound(repo_name))
+      }
+
+      throw externalError
+    }
+  }
+
   async addMemberToRepository(repo_name: string, username: string) {
     await this.getOwner()
     await this.memberExist(username)

--- a/app/services/gitea_api_service.ts
+++ b/app/services/gitea_api_service.ts
@@ -45,7 +45,7 @@ export default class GiteaApiService {
   }
 
   async addMemberToRepository(repo_name: string, username: string) {
-    await this.getOWner()
+    await this.getOwner()
     await this.memberExist(username)
     const url = `/repos/${this.owner_name}/${repo_name}/collaborators/${username}`
     const body = {
@@ -69,7 +69,7 @@ export default class GiteaApiService {
     webhook: GiteaWebhook,
     protection: GiteaProtectedBranch
   ) {
-    await this.getOWner()
+    await this.getOwner()
     let newName = `${repo_name}-${members.join('-')}`
     let membersRepo = await this.createRepoFromTemplate(repo_name, newName)
     let repoName = membersRepo.data.name
@@ -130,7 +130,7 @@ export default class GiteaApiService {
   }
 
   async removeCIWebhook(repo_name: string) {
-    await this.getOWner()
+    await this.getOwner()
     const url = `/repos/${this.owner_name}/${repo_name}/hooks`
     try {
       const result = await this.http_service.get(url)
@@ -154,7 +154,7 @@ export default class GiteaApiService {
   }
 
   private async addWebhook(repo_name: string, webhook: GiteaWebhook) {
-    await this.getOWner()
+    await this.getOwner()
     const url = `/repos/${this.owner_name}/${repo_name}/hooks`
     const body = {
       active: true,
@@ -181,7 +181,7 @@ export default class GiteaApiService {
   }
 
   private async deleteWebhook(repo_name: string, webhook_id: number) {
-    await this.getOWner()
+    await this.getOwner()
     const url = `/repos/${this.owner_name}/${repo_name}/hooks/${webhook_id}`
     try {
       return await this.http_service.delete(url)
@@ -249,7 +249,7 @@ export default class GiteaApiService {
     }
   }
 
-  private async getOWner() {
+  private async getOwner() {
     if (this.owner_name) {
       return
     }

--- a/app/services/gitea_api_service.ts
+++ b/app/services/gitea_api_service.ts
@@ -44,6 +44,32 @@ export default class GiteaApiService {
     }
   }
 
+  async migrateRepository(source_url: string, destination_name: string) {
+    const url: string = `/repos/migrate`
+    const body = {
+      clone_addr: source_url,
+      repo_name: destination_name,
+      repo_owner: this.owner_name,
+      service: 'github',
+      private: true,
+    }
+    try {
+      return await this.http_service.post(url, body)
+    } catch (error) {
+      let externalError: ExternalAPIError = new ExternalAPIError(
+        error.response.status,
+        error.response.data,
+        error,
+        error.response.data.message
+      )
+      if (error.response.status === 409) {
+        externalError.addErrorDetails(new GitRepositoryAlreadyExists(destination_name))
+      }
+
+      throw externalError
+    }
+  }
+
   async addMemberToRepository(repo_name: string, username: string) {
     await this.getOwner()
     await this.memberExist(username)

--- a/app/services/gitea_api_service.ts
+++ b/app/services/gitea_api_service.ts
@@ -46,6 +46,7 @@ export default class GiteaApiService {
 
   async migrateRepository(source_url: string, destination_name: string) {
     const url: string = `/repos/migrate`
+    await this.getOwner()
     const body = {
       clone_addr: source_url,
       repo_name: destination_name,

--- a/app/services/github_api_service.ts
+++ b/app/services/github_api_service.ts
@@ -1,0 +1,20 @@
+import { HttpService } from '#services/http_service'
+import { ExternalAPIError } from '#services/custom_error'
+
+export default class GithubApiService {
+  private http_service: HttpService = new HttpService(`https://api.github.com`, {})
+
+  async getTemplatesList() {
+    const url: string = '/orgs/crackito-templates/repos'
+    try {
+      return await this.http_service.get(url)
+    } catch (error) {
+      throw new ExternalAPIError(
+        error.response.status,
+        error.response.data,
+        error,
+        error.response.data.message
+      )
+    }
+  }
+}

--- a/app/services/http_service.ts
+++ b/app/services/http_service.ts
@@ -36,4 +36,11 @@ export class HttpService {
       headers: headers,
     })
   }
+
+  patch(url: string, body: object, headers: object = {}) {
+    headers = { ...this.default_header, ...headers }
+    return this.client.patch(url, body, {
+      headers: headers,
+    })
+  }
 }


### PR DESCRIPTION
Mise en place du système de migration github -> gitea, permettant de créer un repo gitea depuis un repo github
Ajout du service github_api_service, permettant de récupérer la liste des templates de crackito-templates
Ajout d'une méthode pour récupérer le .protected d'un repo

#41